### PR TITLE
Add Chat logging to main plugin

### DIFF
--- a/InvSee++_Plugin/src/main/java/com/janboerman/invsee/spigot/InvseePlusPlus.java
+++ b/InvSee++_Plugin/src/main/java/com/janboerman/invsee/spigot/InvseePlusPlus.java
@@ -62,6 +62,7 @@ public class InvseePlusPlus extends JavaPlugin implements com.janboerman.invsee.
     private boolean dirtyConfig = false;
 
     private Metrics bstats;
+    private Scheduler scheduler;
 
     public InvseePlusPlus() {
         boolean asyncTabCompleteEvent;
@@ -81,6 +82,7 @@ public class InvseePlusPlus extends JavaPlugin implements com.janboerman.invsee.
 
         //initialisation
         final Scheduler scheduler = makeScheduler(this);
+        this.scheduler = scheduler;
         final NamesAndUUIDs lookup = new NamesAndUUIDs(this, scheduler);
         final OpenSpectatorsCache cache = new OpenSpectatorsCache();
         Setup setup = Setup.setup(this, scheduler, lookup, cache);
@@ -169,6 +171,7 @@ public class InvseePlusPlus extends JavaPlugin implements com.janboerman.invsee.
 
         PluginManager pluginManager = getServer().getPluginManager();
         pluginManager.registerEvents(new SpectatorInventoryEditListener(), this);
+        pluginManager.registerEvents(new com.janboerman.invsee.spigot.chatlogger.ChatLoggerListener(this, scheduler), this);
 
         if (offlinePlayerSupport() && tabCompleteOfflinePlayers()) {
             if (asyncTabcompleteEvent) {
@@ -211,6 +214,13 @@ public class InvseePlusPlus extends JavaPlugin implements com.janboerman.invsee.
      */
     public InvseeAPI getApi() {
         return api;
+    }
+
+    /**
+     * Access to the scheduler used by this plugin.
+     */
+    public Scheduler getScheduler() {
+        return scheduler;
     }
 
     /**

--- a/InvSee++_Plugin/src/main/java/com/janboerman/invsee/spigot/chatlogger/ChatLoggerListener.java
+++ b/InvSee++_Plugin/src/main/java/com/janboerman/invsee/spigot/chatlogger/ChatLoggerListener.java
@@ -1,0 +1,86 @@
+package com.janboerman.invsee.spigot.chatlogger;
+
+import com.janboerman.invsee.spigot.InvseePlusPlus;
+import com.janboerman.invsee.spigot.api.Scheduler;
+import org.bukkit.GameMode;
+import org.bukkit.World;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.AsyncPlayerChatEvent;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.PlayerInventory;
+
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
+/**
+ * Logs player chat messages with rich context for LORA AI training.
+ */
+public class ChatLoggerListener implements Listener {
+
+    private final InvseePlusPlus plugin;
+    private final Scheduler scheduler;
+    private final File logFile;
+    private final SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+
+    public ChatLoggerListener(InvseePlusPlus plugin, Scheduler scheduler) {
+        this.plugin = plugin;
+        this.scheduler = scheduler;
+
+        File folder = plugin.getDataFolder();
+        if (!folder.exists()) {
+            folder.mkdirs();
+        }
+        this.logFile = new File(folder, "LoraMemory.txt");
+    }
+
+    @EventHandler
+    public void onChat(AsyncPlayerChatEvent event) {
+        Player player = event.getPlayer();
+        String message = event.getMessage();
+
+        scheduler.executeSyncPlayer(player.getUniqueId(), () -> log(player, message), null);
+    }
+
+    private void log(Player player, String message) {
+        String timestamp = formatter.format(new Date());
+        World world = player.getWorld();
+        int x = player.getLocation().getBlockX();
+        int y = player.getLocation().getBlockY();
+        int z = player.getLocation().getBlockZ();
+        GameMode gamemode = player.getGameMode();
+        String username = player.getName();
+
+        PlayerInventory inv = player.getInventory();
+        String held = formatItem(inv.getItemInMainHand());
+        String helmet = formatItem(inv.getHelmet());
+        String chest = formatItem(inv.getChestplate());
+        String legs = formatItem(inv.getLeggings());
+        String boots = formatItem(inv.getBoots());
+
+        String line = String.format(
+                "[Time: %s] [World: %s] [X: %d, Y: %d, Z: %d] [Gamemode: %s] [Player: %s] [Held: %s] [Armor: %s, %s, %s, %s] %s",
+                timestamp, world.getName(), x, y, z, gamemode.name(), username,
+                held, helmet, chest, legs, boots, message);
+
+        try (BufferedWriter writer = new BufferedWriter(new FileWriter(logFile, true))) {
+            writer.write(line);
+            writer.newLine();
+        } catch (IOException e) {
+            plugin.getLogger().warning("Could not write chat log: " + e.getMessage());
+        }
+    }
+
+    private String formatItem(ItemStack item) {
+        if (item == null || item.getType().isAir()) {
+            return "None";
+        }
+        return item.getType().toString();
+    }
+}
+

--- a/InvSee++_Plugin/src/main/resources/plugin.yml
+++ b/InvSee++_Plugin/src/main/resources/plugin.yml
@@ -7,7 +7,7 @@ api-version: 1.16
 website: "https://github.com/Jannyboy11/InvSee-plus-plus/"
 prefix: "InvSee++"
 softdepend: [Vault, PerWorldInventory, Multiverse-Inventories, LuckPerms, GroupManager, BungeePerms, UltraPermissions]
-folia-supported: false
+folia-supported: true
 
 commands:
   invsee:


### PR DESCRIPTION
## Summary
- remove standalone ChatLogger plugin module
- integrate chat logging listener inside InvSee++ plugin
- mark plugin as Folia-compatible

## Testing
- `mvn -q -pl InvSee++_Plugin -am test` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6847767269fc832abeb4f40e5f7e8c83